### PR TITLE
⚖️ comply with `cyberscape`'s MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Chris Titus
+Copyright (c) 2022 Isak Solheim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
The [cyberscape theme](https://github.com/isaksolheim/cyberscape) is licensed under MIT License.
The license states:

> The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

Not including the notice would be **illegal**!!!
We don't want that.

Even though `themes/cyberscape` technically links to [cyberscape](https://github.com/isaksolheim/cyberscape/tree/7bb6eda37240e30f9eb7aec14228c0dc958fe121) which includes a `LICENSE` file, it'd be nice to have the license attached here. (`layouts/partials`)
